### PR TITLE
Instead of passing the auth'd name, let slack deal with it

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,8 @@ date | slackcat -c general -p
 slackcat -u buddy -p foo.txt bar.txt
 ```
 
-Due to a limitation of the slack api, your user icon will not be set,
-and your username will appear as `username (bot)`. You may also pass
-only one channel, group or username.
+Due to a limitation of the slack api you may also pass only one channel,
+group or username.
 
 ## Example usage from vim
 

--- a/bin/slackcat
+++ b/bin/slackcat
@@ -135,7 +135,7 @@ params = {
 }.select { |_, value| value }
 
 if opts[:post] #simple text post
-  slack.post_message(text: ARGF.read, channel: params[:channels], username: slack.auth)
+  slack.post_message(text: ARGF.read, channel: params[:channels], as_user: true)
 elsif opts[:multipart] #upload multiple individual binary files
   ARGV.each do |arg|
     slack.upload({file: File.new(arg), filename: arg}.merge(params))


### PR DESCRIPTION
This effectively does the exact same thing as `username: slack.auth`.  Except that it will retain the icon for the authed user in the message.