### PR TITLE
The 'url' parameter for file objects is deprecated. 

### DIFF
--- a/bin/slackcat
+++ b/bin/slackcat
@@ -69,7 +69,7 @@ class Slackcat
       raise "error retrieving information for for file #{params[:file]}: #{response.fetch('error', 'unknown error')}" unless response['ok']
     end.fetch('file')
 
-    if download = info['url']
+    if download = info['url_private']
       uri  = URI(download)
       name = uri.path.split('/').last
 


### PR DESCRIPTION
Using 'url_private' instead for downloading files
