### PR TITLE
.slackcat file for default channel settings based on the local directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.slackcat
+.ruby-version
+.DS_Store

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    slackcat (0.2.5)
+    slackcat (0.2.6)
       httmultiparty
       trollop
 
@@ -12,15 +12,13 @@ GEM
       httparty (>= 0.7.3)
       mimemagic
       multipart-post
-    httparty (0.13.3)
-      json (~> 1.8)
+    httparty (0.14.0)
       multi_xml (>= 0.5.2)
-    json (1.8.2)
-    mimemagic (0.2.1)
+    mimemagic (0.3.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     rake (10.3.2)
-    trollop (2.1.1)
+    trollop (2.1.2)
 
 PLATFORMS
   ruby
@@ -29,3 +27,6 @@ DEPENDENCIES
   bundler (~> 1.3)
   rake
   slackcat!
+
+BUNDLED WITH
+   1.12.3

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ derivatives, you need to install the `ruby-dev` package.
             --multipart, -m:   Multipart upload each file
          --download, -d <s>:   Download a linked file
           --save-as, -s <s>:   Save downloaded file as
+	  --local_channel, -l <s>:   Generate a .slackcat file with the default channel
                  --help, -h:   Show this message
 ```
 

--- a/bin/slackcat
+++ b/bin/slackcat
@@ -2,6 +2,7 @@
 
 require 'httmultiparty'
 require 'trollop'
+require 'yaml'
 
 class Slackcat
   include HTTMultiParty
@@ -90,9 +91,20 @@ class Slackcat
 
 end
 
+
+def local_settings
+	@local_settings ||= File.exists?(".slackcat") ? YAML.load_file('.slackcat') : nil
+end
+
+
+def default_channel
+	local_settings ?  local_settings["default_channel"] : ''
+end
+
 opts = Trollop::options do
+
   opt :token,           'Slack API token',            type: :string,  short: 'k', default: ENV.fetch('SLACK_TOKEN', nil)
-  opt :channels,        'Channels to share',          type: :string,  short: 'c', default: ''
+	opt :channels,        'Channels to share',          type: :string,  short: 'c', default: default_channel
   opt :groups,          'Groups to share',            type: :string,  short: 'g', default: ''
   opt :users,           'Users (DMs) to share',       type: :string,  short: 'u', default: ''
   opt :filetype,        'File type identifier',       type: :string,  short: 't'
@@ -103,7 +115,17 @@ opts = Trollop::options do
   opt :multipart,       'Multipart upload each file', type: :boolean, short: 'm', default: false
   opt :download,        'Download a linked file',     type: :string,  short: 'd'
   opt :save_as,         'Save downloaded file as',    type: :string,  short: 's'
+	opt :local_channel, 	'Set the default channel for the current directory', type: :string, short: "l"
 end
+
+
+if opts[:local_channel]
+	value =  opts[:local_channel]
+	settings = {"default_channel" => value}
+	File.open('.slackcat', 'w') {|f| f.write settings.to_yaml }
+	exit
+end
+
 
 raise 'set slack API token using SLACK_TOKEN or -k option' unless opts[:token]
 slack = Slackcat.new(opts[:token])

--- a/lib/slackcat/version.rb
+++ b/lib/slackcat/version.rb
@@ -1,3 +1,3 @@
 module Slackcat
-  VERSION = "0.2.5"
+  VERSION = "0.2.6"
 end


### PR DESCRIPTION
Added .slackcat file and .slackfile generator to allow for a default channel to be set on the local directory.

Usage is
slackcat -l channel_name

A .slackcat file (yaml with default_channel: channel_name) is created in the local directory. The user can then run slackcat without specifying the channel in that directory. The can then go to a different directory and set a different channel. The settings are not recursive. 
