### PR TITLE
Update trollop dependency to optimist

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     slackcat (0.2.5)
       httmultiparty
-      trollop
+      optimist
 
 GEM
   remote: https://rubygems.org/
@@ -20,7 +20,7 @@ GEM
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     rake (10.3.2)
-    trollop (2.1.1)
+    optimist (2.1.1)
 
 PLATFORMS
   ruby

--- a/bin/slackcat
+++ b/bin/slackcat
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'httmultiparty'
-require 'trollop'
+require 'optimist'
 
 class Slackcat
   include HTTMultiParty
@@ -90,7 +90,7 @@ class Slackcat
 
 end
 
-opts = Trollop::options do
+opts = Optimist::options do
   opt :token,           'Slack API token',            type: :string,  short: 'k', default: ENV.fetch('SLACK_TOKEN', nil)
   opt :channels,        'Channels to share',          type: :string,  short: 'c', default: ''
   opt :groups,          'Groups to share',            type: :string,  short: 'g', default: ''

--- a/lib/slackcat/version.rb
+++ b/lib/slackcat/version.rb
@@ -1,3 +1,3 @@
 module Slackcat
-  VERSION = "0.2.5"
+  VERSION = "0.2.6"
 end

--- a/slackcat.gemspec
+++ b/slackcat.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", "~> 0"
 
-  spec.add_dependency 'httmultiparty'
-  spec.add_dependency 'trollop'
+  spec.add_dependency 'httmultiparty', '~> 0'
+  spec.add_dependency 'optimist', '>= 3.0.0'
 end


### PR DESCRIPTION
Hi, this PR will update the trollop dependency so that the client no longer gives an error for a deprecated library.

I am in no way a Ruby developer, so if there is any issues with this, please let me know.